### PR TITLE
Remove tag leakthrough, fix #1

### DIFF
--- a/lib/Formatter.js
+++ b/lib/Formatter.js
@@ -13,13 +13,35 @@ class Formatter {
     get template() { return this.#template_array.map(v => this.keys.includes(v) ? `:${v}` : v ).join(""); }
     get keys() { return this.#keys; }
 
+    /**
+     * format
+     * Format a string using the template
+     *
+     * @param {string} data the string to format
+     * @param {object} opts data for injection
+     * @returns {string} the formatted string
+     */
     format(data,opts={}) {
         let params = { STRING:data, ...opts};
         return this.#template_array.reduce((agg, cur, idx) => {
-            return agg + (params[this.#key_map.get(idx)] || cur);
+            if ( this.#key_map.has(idx) ) {
+                return agg + (params[this.#key_map.get(idx)] || "");    // We are a tag...if no value, don't add
+            } else {
+                return agg + (params[this.#key_map.get(idx)] || cur);
+            }
+
         },"");
     }
 
+    /**
+     * New formatter
+     *
+     * from a template string
+     *
+     * @static
+     * @param {string} template a template string like "this is a :STRING test"
+     * @returns {Formatter} the new Formatter
+     */
     static from_template(template) {
         let template_array = [];
         let keys = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
         "eslint-plugin-node": "^11.1.0",
         "jsdoc-to-markdown": "^8.0.0",
         "mocha": "^10.2.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/test/test-formatter.js
+++ b/test/test-formatter.js
@@ -34,6 +34,7 @@ describe("Formatter", function() {
             expect(f.keys[1]).to.equal("STRING");
             expect(f.template).to.equal(":ISO - this is a test:STRING");
         });
+
     });
     describe("#format()", function() {
         it("Just returns default", function() {
@@ -51,6 +52,12 @@ describe("Formatter", function() {
         it("Add arguments", function() {
             const f = Formatter.from_template(":ISO - Some :STRING text to");
             expect(f.format("test", {ISO:"a"})).to.equal("a - Some test text to");
+        });
+        it("Doesn't leak through unused tags", function() {
+            const f = Formatter.from_template("this is a :STRING test");
+            let result = f.format("", {});
+            expect(result).to.equal("this is a  test");
+
         });
     });
 });


### PR DESCRIPTION
Fixes tag leakthrough when no matching variable is supplied